### PR TITLE
Add CLI entrypoint for recommendation engine

### DIFF
--- a/vehicle_assistant/README.md
+++ b/vehicle_assistant/README.md
@@ -1,0 +1,55 @@
+# Vehicle Assistant Recommendation Engine
+
+本模块提供一个简单的基于规则的推理引擎, 用于根据车内外状态事件生成可推荐的功能或提示。当前实现旨在作为后续智能座舱功能推荐系统的初步雏形。
+
+## 功能特性
+- 使用 Python 实现的轻量级规则匹配。
+- 支持将一组事件状态输入引擎, 输出匹配规则的推荐提示。
+- 默认规则可以扩展, 也可以在初始化引擎时自定义。
+
+## 快速开始
+```python
+from vehicle_assistant import RecommendationEngine
+
+engine = RecommendationEngine()
+recommendations = engine.recommend({
+    "gear": "P",
+    "passenger_front_door": "open",
+    "environment_puddle_nearby": True,
+})
+for item in recommendations:
+    print(item)
+```
+
+## 命令行使用
+
+本项目内置了一个简单的 CLI, 便于在没有集成环境的情况下快速验证事件输入与推荐输出。安装依赖后可以直接运行:
+
+```bash
+python -m vehicle_assistant.cli --event gear=P passenger_front_door=open environment_puddle_nearby=true
+```
+
+或使用 JSON 字符串传入复杂事件:
+
+```bash
+python -m vehicle_assistant.cli --json '{"gear": "P", "passenger_front_door": "opening", "environment_puddle_nearby": true}'
+```
+
+当没有匹配到任何规则时, CLI 会输出 `暂无推荐。`。
+
+## 目录结构
+```
+vehicle_assistant/
+├── README.md              # 模块简介
+├── __init__.py            # 包初始化, 暴露主要 API
+├── engine.py              # 推荐引擎核心逻辑
+├── rules.py               # 默认规则定义
+└── tests/
+    └── test_engine.py     # 针对推荐引擎的基础测试
+```
+
+## 开发计划
+- 支持更复杂的事件条件组合(如范围、比较等)。
+- 提供规则配置文件的加载与保存。
+- 集成自然语言生成模块, 输出更加丰富的推荐描述。
+```

--- a/vehicle_assistant/__init__.py
+++ b/vehicle_assistant/__init__.py
@@ -1,0 +1,5 @@
+"""Vehicle Assistant Recommendation Engine package."""
+
+from .engine import RecommendationEngine, RecommendationRule
+
+__all__ = ["RecommendationEngine", "RecommendationRule"]

--- a/vehicle_assistant/cli.py
+++ b/vehicle_assistant/cli.py
@@ -1,0 +1,104 @@
+"""Command-line interface for the vehicle assistant recommendation engine."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Dict, Iterable, List
+
+from .engine import RecommendationEngine
+
+
+def _coerce_value(value: str) -> object:
+    """Convert string inputs into Python primitives when possible."""
+
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+
+    try:
+        if value.startswith("0") and value != "0":
+            raise ValueError
+        return int(value)
+    except ValueError:
+        pass
+
+    try:
+        return float(value)
+    except ValueError:
+        return value
+
+
+def _parse_event_pairs(pairs: Iterable[str]) -> Dict[str, object]:
+    """Turn key=value CLI arguments into an event state dictionary."""
+
+    event_state: Dict[str, object] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise ValueError(f"事件参数需要使用 key=value 形式, 当前输入: '{pair}'")
+        key, value = pair.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError(f"事件键名不能为空: '{pair}'")
+        event_state[key] = _coerce_value(value.strip())
+    return event_state
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="车辆场景推荐引擎 CLI")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--json",
+        help="使用 JSON 字符串传入事件状态, 例如 '{\"gear\": \"P\"}'",
+    )
+    group.add_argument(
+        "--event",
+        nargs="+",
+        metavar="KEY=VALUE",
+        help="使用若干 key=value 对描述事件状态",
+    )
+    return parser
+
+
+def _load_event_state(args: argparse.Namespace) -> Dict[str, object]:
+    if getattr(args, "json", None):
+        try:
+            event_state = json.loads(args.json)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"无法解析 JSON: {exc.msg}") from exc
+        if not isinstance(event_state, dict):
+            raise ValueError("JSON 输入必须是对象类型, 例如 {'gear': 'P'}。")
+        return event_state
+
+    try:
+        return _parse_event_pairs(args.event or [])
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+
+
+def main(argv: List[str] | None = None) -> int:
+    """Entrypoint used by ``python -m vehicle_assistant.cli``."""
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        event_state = _load_event_state(args)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    engine = RecommendationEngine()
+    recommendations = engine.recommend(event_state)
+
+    if not recommendations:
+        print("暂无推荐。")
+        return 0
+
+    for item in recommendations:
+        print(f"- {item}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/vehicle_assistant/engine.py
+++ b/vehicle_assistant/engine.py
@@ -1,0 +1,62 @@
+"""Core recommendation engine for vehicle assistant."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class RecommendationRule:
+    """A rule that turns a matching event state into a recommendation."""
+
+    name: str
+    required_state: Dict[str, object]
+    recommendation: str
+    tags: List[str] = field(default_factory=list)
+
+    def matches(self, event_state: Dict[str, object]) -> bool:
+        """Return True if the event_state satisfies the rule's requirements."""
+        for key, expected_value in self.required_state.items():
+            if callable(expected_value):
+                if not expected_value(event_state.get(key)):
+                    return False
+            elif isinstance(expected_value, Iterable) and not isinstance(expected_value, (str, bytes)):
+                if event_state.get(key) not in expected_value:
+                    return False
+            else:
+                if event_state.get(key) != expected_value:
+                    return False
+        return True
+
+
+class RecommendationEngine:
+    """Simple rule-based recommendation engine for in-vehicle events."""
+
+    def __init__(self, rules: Optional[Iterable[RecommendationRule]] = None):
+        self._rules: List[RecommendationRule] = list(rules) if rules is not None else []
+        if rules is None:
+            self._load_default_rules()
+
+    def _load_default_rules(self) -> None:
+        """Populate engine with baseline rules that demonstrate the concept."""
+        from .rules import DEFAULT_RULES
+
+        self._rules.extend(DEFAULT_RULES)
+
+    @property
+    def rules(self) -> List[RecommendationRule]:
+        """Return a copy of the currently configured rules."""
+        return list(self._rules)
+
+    def add_rule(self, rule: RecommendationRule) -> None:
+        """Add a new rule to the engine."""
+        self._rules.append(rule)
+
+    def recommend(self, event_state: Dict[str, object]) -> List[str]:
+        """Return recommendations for a given event_state."""
+        recommendations: List[str] = []
+        for rule in self._rules:
+            if rule.matches(event_state):
+                recommendations.append(rule.recommendation)
+        return recommendations

--- a/vehicle_assistant/rules.py
+++ b/vehicle_assistant/rules.py
@@ -1,0 +1,31 @@
+"""Default rules for the vehicle assistant recommendation engine."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .engine import RecommendationRule
+
+DEFAULT_RULES: List[RecommendationRule] = [
+    RecommendationRule(
+        name="park_with_puddle",
+        required_state={
+            "gear": {"P", "p"},
+            "passenger_front_door": {"open", "opening"},
+            "environment_puddle_nearby": True,
+        },
+        recommendation="副驾下车请注意脚下积水, 下车时观察周围环境以确保安全。",
+        tags=["safety", "environment"],
+    ),
+    RecommendationRule(
+        name="park_with_traffic",
+        required_state={
+            "gear": {"P", "N"},
+            "driver_door": {"open", "opening"},
+            "environment_vehicles_passing": True,
+        },
+        recommendation="下车前请确认后方是否有来车, 建议开启盲区提醒或后视摄像头。",
+        tags=["safety", "traffic"],
+    ),
+]
+"""List of baseline rules used by :class:`vehicle_assistant.engine.RecommendationEngine`."""

--- a/vehicle_assistant/tests/test_cli.py
+++ b/vehicle_assistant/tests/test_cli.py
@@ -1,0 +1,93 @@
+"""Tests for the CLI utilities of the vehicle assistant package."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+from typing import List
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from vehicle_assistant.cli import _coerce_value, _parse_event_pairs, main
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("true", True),
+        ("FALSE", False),
+        ("10", 10),
+        ("3.14", pytest.approx(3.14)),
+        ("leading", "leading"),
+    ],
+)
+def test_coerce_value(value: str, expected) -> None:
+    assert _coerce_value(value) == expected
+
+
+def test_parse_event_pairs_handles_multiple_values() -> None:
+    pairs = [
+        "gear=P",
+        "passenger_front_door=open",
+        "environment_puddle_nearby=true",
+        "speed=12",
+    ]
+
+    event_state = _parse_event_pairs(pairs)
+
+    assert event_state == {
+        "gear": "P",
+        "passenger_front_door": "open",
+        "environment_puddle_nearby": True,
+        "speed": 12,
+    }
+
+
+def test_parse_event_pairs_rejects_invalid_items() -> None:
+    with pytest.raises(ValueError):
+        _parse_event_pairs(["invalid"])
+
+
+@pytest.mark.parametrize(
+    "argv,expected_output",
+    [
+        (
+            [
+                "--event",
+                "gear=P",
+                "passenger_front_door=open",
+                "environment_puddle_nearby=true",
+            ],
+            "- 副驾下车请注意脚下积水, 下车时观察周围环境以确保安全。\n",
+        ),
+        (
+            [
+                "--json",
+                json.dumps(
+                    {
+                        "gear": "D",
+                        "driver_door": "closed",
+                    }
+                ),
+            ],
+            "暂无推荐。\n",
+        ),
+    ],
+)
+def test_main_outputs_expected_recommendations(argv: List[str], expected_output: str, capsys):
+    exit_code = main(argv)
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.out == expected_output
+
+
+def test_main_handles_json_type_errors():
+    with pytest.raises(SystemExit) as excinfo:
+        main(["--json", "[]"])
+
+    assert excinfo.value.code == 2

--- a/vehicle_assistant/tests/test_engine.py
+++ b/vehicle_assistant/tests/test_engine.py
@@ -1,0 +1,109 @@
+"""Tests for the vehicle assistant recommendation engine."""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from vehicle_assistant import RecommendationEngine, RecommendationRule
+
+
+@pytest.mark.parametrize(
+    ("event_state", "expected"),
+    [
+        (
+            {
+                "gear": "p",
+                "passenger_front_door": "opening",
+                "environment_puddle_nearby": True,
+            },
+            "副驾下车请注意脚下积水, 下车时观察周围环境以确保安全。",
+        ),
+        (
+            {
+                "gear": "N",
+                "driver_door": "open",
+                "environment_vehicles_passing": True,
+            },
+            "下车前请确认后方是否有来车, 建议开启盲区提醒或后视摄像头。",
+        ),
+    ],
+)
+def test_default_rules_cover_multiple_event_variants(event_state, expected):
+    """Ensure each built-in rule fires for representative event combinations."""
+
+    engine = RecommendationEngine()
+
+    assert engine.recommend(event_state) == [expected]
+
+
+def test_default_rule_matches_puddle_scenario():
+    engine = RecommendationEngine()
+
+    recommendations = engine.recommend(
+        {
+            "gear": "P",
+            "passenger_front_door": "open",
+            "environment_puddle_nearby": True,
+        }
+    )
+
+    assert any("积水" in item for item in recommendations)
+
+
+def test_puddle_scenario_returns_expected_text():
+    """The real-world puddle case from the product discussion should pass."""
+
+    engine = RecommendationEngine()
+
+    recommendations = engine.recommend(
+        {
+            "gear": "P",
+            "passenger_front_door": "open",
+            "environment_puddle_nearby": True,
+            # Extra keys that may appear in the real event payload.
+            "driver_presence": "present",
+            "time_of_day": "night",
+        }
+    )
+
+    assert recommendations == [
+        "副驾下车请注意脚下积水, 下车时观察周围环境以确保安全。"
+    ]
+
+
+def test_no_recommendation_when_state_does_not_match():
+    """An unrelated event should not trigger any default recommendations."""
+
+    engine = RecommendationEngine()
+
+    assert engine.recommend({"gear": "D", "driver_door": "closed"}) == []
+
+
+def test_custom_rule_can_be_added():
+    engine = RecommendationEngine(rules=[])
+    rule = RecommendationRule(
+        name="seatbelt_warning",
+        required_state={"speed": lambda value: value and value > 20},
+        recommendation="当前车速超过 20km/h, 请确认所有乘员系好安全带。",
+    )
+
+    engine.add_rule(rule)
+
+    recommendations = engine.recommend({"speed": 30})
+
+    assert recommendations == ["当前车速超过 20km/h, 请确认所有乘员系好安全带。"]
+
+
+def test_callable_requirement_gracefully_handles_missing_value():
+    """Callable expectations should cope with absent keys without crashing."""
+
+    rule = RecommendationRule(
+        name="check_speed_threshold",
+        required_state={"speed": lambda value: value and value > 20},
+        recommendation="placeholder",
+    )
+
+    assert not rule.matches({})


### PR DESCRIPTION
## Summary
- add a command-line interface for exercising the recommendation engine from terminal inputs
- document CLI usage options in the package README
- cover CLI helpers and end-to-end flows with unit tests

## Testing
- pytest vehicle_assistant/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68f124b78c7c832f98ee39f8111dcfc7